### PR TITLE
Enable additional database tables in DBHelper

### DIFF
--- a/app/src/main/java/com/example/petcare/data/local/DBContract.kt
+++ b/app/src/main/java/com/example/petcare/data/local/DBContract.kt
@@ -27,4 +27,34 @@ object DBContract {
             FOREIGN KEY (id_tipo_mascota) REFERENCES tipo_mascota(id_tipo_mascota)
         );
     """
+
+    const val SQL_CREATE_TIPO_MASCOTA = """
+        CREATE TABLE tipo_mascota (
+            id_tipo_mascota INTEGER PRIMARY KEY AUTOINCREMENT,
+            nombre TEXT NOT NULL
+        );
+    """
+
+    const val SQL_CREATE_TIPO_CITA = """
+        CREATE TABLE tipo_cita (
+            id_tipo_cita INTEGER PRIMARY KEY AUTOINCREMENT,
+            nombre TEXT NOT NULL
+        );
+    """
+
+    const val SQL_CREATE_MASCOTA = """
+        CREATE TABLE mascota (
+            id_mascota INTEGER PRIMARY KEY AUTOINCREMENT,
+            id_tipo_mascota INTEGER NOT NULL,
+            id_raza INTEGER NOT NULL,
+            id_propietario INTEGER NOT NULL,
+            nombre TEXT NOT NULL,
+            edad INTEGER NOT NULL,
+            peso_kg INTEGER NOT NULL,
+            codigo_qr TEXT NOT NULL,
+            FOREIGN KEY (id_tipo_mascota) REFERENCES tipo_mascota(id_tipo_mascota),
+            FOREIGN KEY (id_raza) REFERENCES raza(id_raza),
+            FOREIGN KEY (id_propietario) REFERENCES usuario(id_usuario)
+        );
+    """
 }

--- a/app/src/main/java/com/example/petcare/data/local/DBHelper.kt
+++ b/app/src/main/java/com/example/petcare/data/local/DBHelper.kt
@@ -3,7 +3,10 @@ package com.example.petcare.data.local
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
+import com.example.petcare.data.local.DBContract.SQL_CREATE_MASCOTA
 import com.example.petcare.data.local.DBContract.SQL_CREATE_RAZA
+import com.example.petcare.data.local.DBContract.SQL_CREATE_TIPO_CITA
+import com.example.petcare.data.local.DBContract.SQL_CREATE_TIPO_MASCOTA
 import com.example.petcare.data.local.DBContract.SQL_CREATE_TIPO_USUARIO
 import com.example.petcare.data.local.DBContract.SQL_CREATE_USUARIO
 
@@ -12,11 +15,11 @@ class DBHelper(context: Context) : SQLiteOpenHelper(context, DATABASE_NAME, null
     override fun onCreate(db: SQLiteDatabase) {
         db.execSQL(SQL_CREATE_TIPO_USUARIO)
         db.execSQL(SQL_CREATE_USUARIO)
-//        db.execSQL(SQL_CREATE_TIPO_MASCOTA)
+        db.execSQL(SQL_CREATE_TIPO_MASCOTA)
         db.execSQL(SQL_CREATE_RAZA)
-//        db.execSQL(SQL_CREATE_MASCOTA)
+        db.execSQL(SQL_CREATE_MASCOTA)
 //        db.execSQL(SQL_CREATE_IMAGEN_MASCOTA)
-//        db.execSQL(SQL_CREATE_TIPO_CITA)
+        db.execSQL(SQL_CREATE_TIPO_CITA)
 //        db.execSQL(SQL_CREATE_CITA)
 //        db.execSQL(SQL_CREATE_VACUNA)
 //        db.execSQL(SQL_CREATE_MEDICAMENTO)


### PR DESCRIPTION
- Enabled the creation of `tipo_mascota`, `mascota`, and `tipo_cita` tables in `DBHelper`.
- Added `SQL_CREATE_TIPO_MASCOTA`, `SQL_CREATE_TIPO_CITA`, and `SQL_CREATE_MASCOTA` constants to `DBContract` to define their respective schemas.